### PR TITLE
WIP クロール枚数のログ保持

### DIFF
--- a/enginessl/crawler/system.py
+++ b/enginessl/crawler/system.py
@@ -50,5 +50,5 @@ class Clawler(kernel.Kernel):
         os.makedirs(crawler_logs_path, exist_ok=True)
         with open(crawler_logs_path, 'w') as log:
             status = [self.keyword, self.num]
-            log.write(':'.join(status))
+            log.write(':'.join(status) + '\n')
 

--- a/enginessl/crawler/system.py
+++ b/enginessl/crawler/system.py
@@ -17,6 +17,7 @@ class Clawler(kernel.Kernel):
         self.urls = None
 
     def crawl(self, multiple=1):
+        self.write_crawl_stat()
         self.urls = super().get_url(self.keyword, num=self.num, multiple=multiple)
         print(len(self.urls))
 


### PR DESCRIPTION
まだつかえません
todo: 
* -r パラメータ指定時でparam: crawler: target_num:に依存せず閾値を設定する